### PR TITLE
Remove manager and objective from executor

### DIFF
--- a/fuzzers/baby/baby_fuzzer_custom_executor/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_custom_executor/src/main.rs
@@ -47,18 +47,12 @@ impl<S> CustomExecutor<S> {
     }
 }
 
-impl<EM, I, OF, S> Executor<EM, I, OF, S> for CustomExecutor<S>
+impl<EM, I, OF, S> Executor<I, S> for CustomExecutor<S>
 where
     S: HasCorpus<I> + HasExecutions,
     I: HasTargetBytes,
 {
-    fn run_target(
-        &mut self,
-        _objective: &mut OF,
-        state: &mut S,
-        _mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, libafl::Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, libafl::Error> {
         // We need to keep track of the exec count.
         *state.executions_mut() += 1;
 

--- a/fuzzers/forkserver/libafl-fuzz/src/executor.rs
+++ b/fuzzers/forkserver/libafl-fuzz/src/executor.rs
@@ -258,18 +258,12 @@ pub enum SupportedExecutors<FSV, I, OT, NYX> {
 }
 
 #[cfg(feature = "nyx")]
-impl<S, I, OT, FSV, NYX, EM, Z> Executor<EM, I, S, Z> for SupportedExecutors<FSV, I, OT, NYX>
+impl<S, I, OT, FSV, NYX, EM, Z> Executor<I, S> for SupportedExecutors<FSV, I, OT, NYX>
 where
-    NYX: Executor<EM, I, S, Z>,
-    FSV: Executor<EM, I, S, Z>,
+    NYX: Executor<I, S>,
+    FSV: Executor<I, S>,
 {
-    fn run_target(
-        &mut self,
-        fuzzer: &mut Z,
-        state: &mut S,
-        mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
         match self {
             Self::Forkserver(fsrv, _) => fsrv.run_target(fuzzer, state, mgr, input),
             #[cfg(feature = "nyx")]
@@ -332,20 +326,14 @@ pub enum SupportedExecutors<FSV, I, OT, S> {
 }
 
 #[cfg(not(feature = "nyx"))]
-impl<S, I, OF, OT, FSV, EM> Executor<EM, I, OF, S> for SupportedExecutors<FSV, I, OT, S>
+impl<S, I, OF, OT, FSV, EM> Executor<I, S> for SupportedExecutors<FSV, I, OT, S>
 where
     S: HasCorpus<I>,
-    FSV: Executor<EM, I, OF, S>,
+    FSV: Executor<I, S>,
 {
-    fn run_target(
-        &mut self,
-        objective: &mut OF,
-        state: &mut S,
-        mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
         match self {
-            Self::Forkserver(fsrv, _) => fsrv.run_target(objective, state, mgr, input),
+            Self::Forkserver(fsrv, _) => fsrv.run_target(state, input),
         }
     }
 }

--- a/libafl/src/executors/combined.rs
+++ b/libafl/src/executors/combined.rs
@@ -35,19 +35,13 @@ impl<A, B> CombinedExecutor<A, B> {
     }
 }
 
-impl<A, B, EM, I, OF, S> Executor<EM, I, OF, S> for CombinedExecutor<A, B>
+impl<A, B, I, S> Executor<I, S> for CombinedExecutor<A, B>
 where
-    A: Executor<EM, I, OF, S>,
-    B: Executor<EM, I, OF, S>,
+    A: Executor<I, S>,
+    B: Executor<I, S>,
 {
-    fn run_target(
-        &mut self,
-        objective: &mut OF,
-        state: &mut S,
-        mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
-        self.primary.run_target(objective, state, mgr, input)
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
+        self.primary.run_target(state, input)
     }
 }
 

--- a/libafl/src/executors/differential.rs
+++ b/libafl/src/executors/differential.rs
@@ -59,29 +59,22 @@ impl<A, B, DOT, I, OTA, OTB, S> DiffExecutor<A, B, DOT, I, OTA, OTB, S> {
     }
 }
 
-impl<A, B, DOT, EM, I, OF, S> Executor<EM, I, OF, S>
-    for DiffExecutor<A, B, DOT, I, A::Observers, B::Observers, S>
+impl<A, B, DOT, I, S> Executor<I, S> for DiffExecutor<A, B, DOT, I, A::Observers, B::Observers, S>
 where
-    A: Executor<EM, I, OF, S> + HasObservers,
-    B: Executor<EM, I, OF, S> + HasObservers,
+    A: Executor<I, S> + HasObservers,
+    B: Executor<I, S> + HasObservers,
     <A as HasObservers>::Observers: ObserversTuple<I, S>,
     <B as HasObservers>::Observers: ObserversTuple<I, S>,
     DOT: DifferentialObserversTuple<A::Observers, B::Observers, I, S> + MatchName,
 {
-    fn run_target(
-        &mut self,
-        objective: &mut OF,
-        state: &mut S,
-        mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
         self.observers(); // update in advance
         let observers = self.observers.get_mut();
         observers
             .differential
             .pre_observe_first_all(observers.primary.as_mut())?;
         observers.primary.as_mut().pre_exec_all(state, input)?;
-        let ret1 = self.primary.run_target(objective, state, mgr, input)?;
+        let ret1 = self.primary.run_target(state, input)?;
         observers
             .primary
             .as_mut()
@@ -93,7 +86,7 @@ where
             .differential
             .pre_observe_second_all(observers.secondary.as_mut())?;
         observers.secondary.as_mut().pre_exec_all(state, input)?;
-        let ret2 = self.secondary.run_target(objective, state, mgr, input)?;
+        let ret2 = self.secondary.run_target(state, input)?;
         observers
             .secondary
             .as_mut()

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -1570,7 +1570,7 @@ impl Default
     }
 }
 
-impl<EM, I, OF, OT, S, SHM, TC> Executor<EM, I, OF, S> for ForkserverExecutor<I, OT, S, SHM, TC>
+impl<I, OT, S, SHM, TC> Executor<I, S> for ForkserverExecutor<I, OT, S, SHM, TC>
 where
     OT: ObserversTuple<I, S>,
     S: HasExecutions,
@@ -1578,13 +1578,7 @@ where
     SHM: ShMem,
 {
     #[inline]
-    fn run_target(
-        &mut self,
-        _objective: &mut OF,
-        state: &mut S,
-        _mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
         self.execute_input(state, input)
     }
 }

--- a/libafl/src/executors/hooks/inprocess.rs
+++ b/libafl/src/executors/hooks/inprocess.rs
@@ -216,7 +216,7 @@ impl<I, S> InProcessHooks<I, S> {
     #[allow(unused_variables)] // for `exec_tmout` without `std`
     pub fn new<E, EM, OF>(exec_tmout: Duration) -> Result<Self, Error>
     where
-        E: Executor<EM, I, OF, S> + HasObservers + HasInProcessHooks<I, S>,
+        E: Executor<I, S> + HasObservers + HasInProcessHooks<I, S>,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         OF: Feedback<EM, I, E::Observers, S>,
@@ -258,7 +258,7 @@ impl<I, S> InProcessHooks<I, S> {
     #[allow(unused_variables)] // for `exec_tmout` without `std`
     pub fn new<E, EM, OF>(exec_tmout: Duration) -> Result<Self, Error>
     where
-        E: Executor<EM, I, OF, S> + HasObservers + HasInProcessHooks<I, S>,
+        E: Executor<I, S> + HasObservers + HasInProcessHooks<I, S>,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         I: Input + Clone,
@@ -317,7 +317,7 @@ impl<I, S> InProcessHooks<I, S> {
     #[expect(unused_variables)]
     pub fn new<E, EM, OF>(exec_tmout: Duration) -> Result<Self, Error>
     where
-        E: Executor<EM, I, OF, S> + HasObservers + HasInProcessHooks<I, S>,
+        E: Executor<I, S> + HasObservers + HasInProcessHooks<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         OF: Feedback<EM, I, E::Observers, S>,
         S: HasExecutions + HasSolutions<I>,

--- a/libafl/src/executors/hooks/unix.rs
+++ b/libafl/src/executors/hooks/unix.rs
@@ -77,7 +77,7 @@ pub mod unix_signal_handler {
     /// invokes the `post_exec` hook on all observer in case of panic
     pub fn setup_panic_hook<E, EM, I, OF, S>()
     where
-        E: Executor<EM, I, OF, S> + HasObservers,
+        E: Executor<I, S> + HasObservers,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         OF: Feedback<EM, I, E::Observers, S>,
@@ -125,7 +125,7 @@ pub mod unix_signal_handler {
         _context: Option<&mut ucontext_t>,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        E: Executor<EM, I, OF, S> + HasInProcessHooks<I, S> + HasObservers,
+        E: Executor<I, S> + HasInProcessHooks<I, S> + HasObservers,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         OF: Feedback<EM, I, E::Observers, S>,
@@ -180,7 +180,7 @@ pub mod unix_signal_handler {
         _context: Option<&mut ucontext_t>,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        E: Executor<EM, I, OF, S> + HasObservers,
+        E: Executor<I, S> + HasObservers,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         OF: Feedback<EM, I, E::Observers, S>,

--- a/libafl/src/executors/hooks/windows.rs
+++ b/libafl/src/executors/hooks/windows.rs
@@ -24,7 +24,7 @@ pub mod windows_asan_handler {
     /// ASAN deatch handler
     pub unsafe extern "C" fn asan_death_handler<E, EM, I, OF, S>()
     where
-        E: Executor<EM, I, OF, S> + HasObservers,
+        E: Executor<I, S> + HasObservers,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         I: Input + Clone,
@@ -178,7 +178,7 @@ pub mod windows_exception_handler {
     #[cfg(feature = "std")]
     pub fn setup_panic_hook<E, EM, I, OF, S>()
     where
-        E: Executor<EM, I, OF, S> + HasObservers,
+        E: Executor<I, S> + HasObservers,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         I: Input + Clone,
@@ -239,7 +239,7 @@ pub mod windows_exception_handler {
         global_state: *mut c_void,
         _p1: *mut u8,
     ) where
-        E: Executor<EM, I, OF, S> + HasInProcessHooks<I, S> + HasObservers,
+        E: Executor<I, S> + HasInProcessHooks<I, S> + HasObservers,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         I: Input + Clone,
@@ -307,7 +307,7 @@ pub mod windows_exception_handler {
         exception_pointers: *mut EXCEPTION_POINTERS,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        E: Executor<EM, I, OF, S> + HasObservers,
+        E: Executor<I, S> + HasObservers,
         E::Observers: ObserversTuple<I, S>,
         EM: EventFirer<I, S> + EventRestarter<S>,
         I: Input + Clone,

--- a/libafl/src/executors/shadow.rs
+++ b/libafl/src/executors/shadow.rs
@@ -64,19 +64,13 @@ where
     }
 }
 
-impl<E, EM, I, OF, S, SOT> Executor<EM, I, OF, S> for ShadowExecutor<E, I, S, SOT>
+impl<E, I, S, SOT> Executor<I, S> for ShadowExecutor<E, I, S, SOT>
 where
-    E: Executor<EM, I, OF, S> + HasObservers,
+    E: Executor<I, S> + HasObservers,
     SOT: ObserversTuple<I, S>,
 {
-    fn run_target(
-        &mut self,
-        objective: &mut OF,
-        state: &mut S,
-        mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
-        self.executor.run_target(objective, state, mgr, input)
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
+        self.executor.run_target(state, input)
     }
 }
 

--- a/libafl/src/executors/with_observers.rs
+++ b/libafl/src/executors/with_observers.rs
@@ -18,18 +18,12 @@ pub struct WithObservers<E, I, OT, S> {
     phantom: PhantomData<(I, S)>,
 }
 
-impl<E, EM, I, OF, OT, S> Executor<EM, I, OF, S> for WithObservers<E, I, OT, S>
+impl<E, I, OT, S> Executor<I, S> for WithObservers<E, I, OT, S>
 where
-    E: Executor<EM, I, OF, S>,
+    E: Executor<I, S>,
 {
-    fn run_target(
-        &mut self,
-        objective: &mut OF,
-        state: &mut S,
-        mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
-        self.executor.run_target(objective, state, mgr, input)
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
+        self.executor.run_target(state, input)
     }
 }
 

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -513,7 +513,7 @@ where
 impl<CS, E, EM, F, I, IF, OF, S> EvaluatorObservers<E, EM, I, S> for StdFuzzer<CS, F, IF, OF>
 where
     CS: Scheduler<I, S>,
-    E: HasObservers + Executor<EM, I, OF, S>,
+    E: HasObservers + Executor<I, S>,
     E::Observers: MatchName + ObserversTuple<I, S> + Serialize,
     EM: EventFirer<I, S> + CanSerializeObserver<E::Observers>,
     F: Feedback<EM, I, E::Observers, S>,
@@ -588,7 +588,7 @@ impl<I: Hash> InputFilter<I> for BloomInputFilter {
 impl<CS, E, EM, F, I, IF, OF, S> Evaluator<E, EM, I, S> for StdFuzzer<CS, F, IF, OF>
 where
     CS: Scheduler<I, S>,
-    E: HasObservers + Executor<EM, I, OF, S>,
+    E: HasObservers + Executor<I, S>,
     E::Observers: MatchName + ObserversTuple<I, S> + Serialize,
     EM: EventFirer<I, S> + CanSerializeObserver<E::Observers>,
     F: Feedback<EM, I, E::Observers, S>,
@@ -916,7 +916,7 @@ pub trait ExecutesInput<E, EM, I, S> {
 impl<CS, E, EM, F, I, IF, OF, S> ExecutesInput<E, EM, I, S> for StdFuzzer<CS, F, IF, OF>
 where
     CS: Scheduler<I, S>,
-    E: Executor<EM, I, OF, S> + HasObservers,
+    E: Executor<I, S> + HasObservers,
     E::Observers: ObserversTuple<I, S>,
     S: HasExecutions + HasCorpus<I> + MaybeHasClientPerfMonitor,
 {
@@ -925,7 +925,7 @@ where
         &mut self,
         state: &mut S,
         executor: &mut E,
-        event_mgr: &mut EM,
+        _event_mgr: &mut EM,
         input: &I,
     ) -> Result<ExitKind, Error> {
         start_timer!(state);
@@ -933,7 +933,7 @@ where
         mark_feature_time!(state, PerfFeature::PreExecObservers);
 
         start_timer!(state);
-        let exit_kind = executor.run_target(&mut self.objective, state, event_mgr, input)?;
+        let exit_kind = executor.run_target(state, input)?;
         mark_feature_time!(state, PerfFeature::TargetExecution);
 
         start_timer!(state);

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -91,7 +91,7 @@ pub struct CalibrationStage<C, E, I, O, OT, S> {
 
 impl<C, E, EM, I, O, OT, S, Z> Stage<E, EM, S, Z> for CalibrationStage<C, E, I, O, OT, S>
 where
-    E: Executor<EM, I, Z::Objective, S> + HasObservers<Observers = OT>,
+    E: Executor<I, S> + HasObservers<Observers = OT>,
     EM: EventFirer<I, S>,
     O: MapObserver,
     C: AsRef<O>,
@@ -111,7 +111,7 @@ where
     #[expect(clippy::too_many_lines, clippy::cast_precision_loss)]
     fn perform(
         &mut self,
-        fuzzer: &mut Z,
+        _fuzzer: &mut Z,
         executor: &mut E,
         state: &mut S,
         mgr: &mut EM,
@@ -135,7 +135,7 @@ where
 
         let mut start = current_time();
 
-        let exit_kind = executor.run_target(fuzzer.objective_mut(), state, mgr, &input)?;
+        let exit_kind = executor.run_target(state, &input)?;
         let mut total_time = if exit_kind == ExitKind::Ok {
             current_time() - start
         } else {
@@ -184,7 +184,7 @@ where
             executor.observers_mut().pre_exec_all(state, &input)?;
             start = current_time();
 
-            let exit_kind = executor.run_target(fuzzer.objective_mut(), state, mgr, &input)?;
+            let exit_kind = executor.run_target(state, &input)?;
             if exit_kind != ExitKind::Ok {
                 if !has_errors {
                     mgr.log(

--- a/libafl/src/stages/concolic.rs
+++ b/libafl/src/stages/concolic.rs
@@ -49,7 +49,7 @@ impl<EM, I, TE, S, Z> Named for ConcolicTracingStage<'_, EM, I, TE, S, Z> {
 
 impl<E, EM, I, TE, S, Z> Stage<E, EM, S, Z> for ConcolicTracingStage<'_, EM, I, TE, S, Z>
 where
-    TE: Executor<EM, I, Z::Objective, S> + HasObservers,
+    TE: Executor<I, S> + HasObservers,
     TE::Observers: ObserversTuple<I, S>,
     S: HasExecutions
         + HasCorpus<I>
@@ -62,12 +62,12 @@ where
     #[inline]
     fn perform(
         &mut self,
-        fuzzer: &mut Z,
+        _fuzzer: &mut Z,
         _executor: &mut E,
         state: &mut S,
-        manager: &mut EM,
+        _manager: &mut EM,
     ) -> Result<(), Error> {
-        self.inner.trace(fuzzer, state, manager)?;
+        self.inner.trace(state)?;
         if let Some(observer) = self.inner.executor().observers().get(&self.observer_handle) {
             let metadata = observer.create_metadata_from_current_map();
             state

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     start_timer,
     state::{HasCurrentTestcase, HasExecutions, HasRand, MaybeHasClientPerfMonitor},
-    Error, HasMetadata, HasNamedMetadata, HasObjective,
+    Error, HasMetadata, HasNamedMetadata,
 };
 
 /// The unique id for this stage
@@ -76,7 +76,7 @@ where
 
 impl<E, F, EM, I, M, S, Z> Stage<E, EM, S, Z> for PowerMutationalStage<E, F, EM, I, M, S, Z>
 where
-    E: Executor<EM, I, Z::Objective, S> + HasObservers,
+    E: Executor<I, S> + HasObservers,
     F: TestcaseScore<I, S>,
     M: Mutator<I, S>,
     S: HasMetadata
@@ -86,7 +86,7 @@ where
         + HasCurrentTestcase<I>
         + HasCurrentCorpusId
         + MaybeHasClientPerfMonitor,
-    Z: Evaluator<E, EM, I, S> + HasObjective,
+    Z: Evaluator<E, EM, I, S>,
     I: MutatedTransform<I, S> + Clone,
 {
     #[inline]
@@ -114,12 +114,12 @@ where
 
 impl<E, F, EM, I, M, S, Z> PowerMutationalStage<E, F, EM, I, M, S, Z>
 where
-    E: Executor<EM, I, Z::Objective, S> + HasObservers,
+    E: Executor<I, S> + HasObservers,
     F: TestcaseScore<I, S>,
     M: Mutator<I, S>,
     S: HasMetadata + HasRand + HasCurrentTestcase<I> + MaybeHasClientPerfMonitor,
     I: MutatedTransform<I, S> + Clone,
-    Z: Evaluator<E, EM, I, S> + HasObjective,
+    Z: Evaluator<E, EM, I, S>,
 {
     /// Creates a new [`PowerMutationalStage`]
     pub fn new(mutator: M) -> Self {

--- a/libafl/src/stages/push/mod.rs
+++ b/libafl/src/stages/push/mod.rs
@@ -255,7 +255,7 @@ where
         + HasCurrentCorpusId
         + HasNamedMetadata
         + HasMetadata,
-    E: Executor<EM, I, Z::Objective, S> + HasObservers<Observers = OT>,
+    E: Executor<I, S> + HasObservers<Observers = OT>,
     EM: EventFirer<I, S> + EventRestarter<S> + HasEventManagerId + ProgressReporter<S>,
     OT: ObserversTuple<I, S>,
     PS: PushStage<EM, I, OT, S, Z>,

--- a/libafl/src/stages/sync.rs
+++ b/libafl/src/stages/sync.rs
@@ -233,7 +233,7 @@ impl<E, EM, I, IC, ICB, DI, S, SHM, SP, Z> Stage<E, EM, S, Z>
 where
     DI: Input,
     EM: EventFirer<I, S>,
-    E: HasObservers + Executor<EM, I, Z::Objective, S>,
+    E: HasObservers + Executor<I, S>,
     for<'a> E::Observers: Deserialize<'a>,
     I: Input + Clone,
     IC: InputConverter<From = I, To = DI>,

--- a/libafl/src/stages/verify_timeouts.rs
+++ b/libafl/src/stages/verify_timeouts.rs
@@ -14,7 +14,7 @@ use crate::{
     inputs::BytesInput,
     observers::ObserversTuple,
     stages::Stage,
-    Evaluator, HasMetadata, HasObjective,
+    Evaluator, HasMetadata,
 };
 
 /// Stage that re-runs inputs deemed as timeouts with double the timeout to assert that they are
@@ -82,8 +82,8 @@ impl<I> TimeoutsToVerify<I> {
 impl<E, EM, I, S, Z> Stage<E, EM, S, Z> for VerifyTimeoutsStage<E, I, S>
 where
     E::Observers: ObserversTuple<I, S>,
-    E: Executor<EM, I, Z::Objective, S> + HasObservers + HasTimeout,
-    Z: Evaluator<E, EM, I, S> + HasObjective,
+    E: Executor<I, S> + HasObservers + HasTimeout,
+    Z: Evaluator<E, EM, I, S>,
     S: HasMetadata,
     I: Debug + Serialize + DeserializeOwned + Default + 'static + Clone,
 {

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -55,8 +55,7 @@ where
     }
 }
 
-impl<EM, H, I, OF, OT, RT, S, TC> Executor<EM, I, OF, S>
-    for FridaInProcessExecutor<'_, '_, '_, H, I, OT, RT, S, TC>
+impl<H, I, OT, RT, S, TC> Executor<I, S> for FridaInProcessExecutor<'_, '_, '_, H, I, OT, RT, S, TC>
 where
     H: FnMut(&I) -> ExitKind,
     S: HasExecutions,
@@ -66,13 +65,7 @@ where
 {
     /// Instruct the target about the input and run
     #[inline]
-    fn run_target(
-        &mut self,
-        objective: &mut OF,
-        state: &mut S,
-        mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
         let target_bytes = self.target_bytes_converter.to_target_bytes(input);
         self.helper.pre_exec(target_bytes.as_slice())?;
         if self.helper.stalker_enabled() {
@@ -92,7 +85,7 @@ where
                 }
             }
         }
-        let res = self.base.run_target(objective, state, mgr, input);
+        let res = self.base.run_target(state, input);
         if self.helper.stalker_enabled() {
             self.stalker.deactivate();
         }

--- a/libafl_nyx/src/executor.rs
+++ b/libafl_nyx/src/executor.rs
@@ -38,19 +38,13 @@ impl NyxExecutor<(), ()> {
     }
 }
 
-impl<EM, I, OF, OT, S> Executor<EM, I, OF, S> for NyxExecutor<S, OT>
+impl<EM, I, OF, OT, S> Executor<I, S> for NyxExecutor<S, OT>
 where
     S: HasExecutions,
     I: HasTargetBytes,
     OT: ObserversTuple<I, S>,
 {
-    fn run_target(
-        &mut self,
-        _objective: &mut OF,
-        state: &mut S,
-        _mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
         *state.executions_mut() += 1;
 
         let bytes = input.target_bytes();

--- a/libafl_targets/src/cmps/stages/aflpptracing.rs
+++ b/libafl_targets/src/cmps/stages/aflpptracing.rs
@@ -36,7 +36,7 @@ impl<EM, TE, S, Z> Named for AFLppCmplogTracingStage<'_, EM, TE, S, Z> {
 
 impl<E, EM, TE, S, Z> Stage<E, EM, S, Z> for AFLppCmplogTracingStage<'_, EM, TE, S, Z>
 where
-    TE: HasObservers + Executor<EM, BytesInput, Z::Objective, S>,
+    TE: HasObservers + Executor<BytesInput, S>,
     TE::Observers: MatchNameRef + ObserversTuple<BytesInput, S>,
     S: HasCorpus<BytesInput>
         + HasCurrentTestcase<BytesInput>
@@ -48,10 +48,10 @@ where
     #[inline]
     fn perform(
         &mut self,
-        fuzzer: &mut Z,
+        _fuzzer: &mut Z,
         _executor: &mut E,
         state: &mut S,
-        manager: &mut EM,
+        _manager: &mut EM,
     ) -> Result<(), Error> {
         // First run with the un-mutated input
         let unmutated_input = state.current_input_cloned()?;
@@ -72,12 +72,7 @@ where
             .observers_mut()
             .pre_exec_all(state, &unmutated_input)?;
 
-        let exit_kind = self.tracer_executor.run_target(
-            fuzzer.objective_mut(),
-            state,
-            manager,
-            &unmutated_input,
-        )?;
+        let exit_kind = self.tracer_executor.run_target(state, &unmutated_input)?;
 
         self.tracer_executor
             .observers_mut()
@@ -105,12 +100,7 @@ where
             .observers_mut()
             .pre_exec_all(state, &mutated_input)?;
 
-        let exit_kind = self.tracer_executor.run_target(
-            fuzzer.objective_mut(),
-            state,
-            manager,
-            &mutated_input,
-        )?;
+        let exit_kind = self.tracer_executor.run_target(state, &mutated_input)?;
 
         self.tracer_executor
             .observers_mut()

--- a/libafl_targets/src/windows_asan.rs
+++ b/libafl_targets/src/windows_asan.rs
@@ -30,7 +30,7 @@ extern "C" {
 /// Calls the unsafe `__sanitizer_set_death_callback` symbol, but should be safe to call otherwise.
 pub unsafe fn setup_asan_callback<E, EM, I, OF, S>(_executor: &E, _event_mgr: &EM, _objective: &OF)
 where
-    E: Executor<EM, I, OF, S> + HasObservers,
+    E: Executor<I, S> + HasObservers,
     E::Observers: ObserversTuple<I, S>,
     EM: EventFirer<I, S> + EventRestarter<S>,
     OF: Feedback<EM, I, E::Observers, S>,

--- a/libafl_tinyinst/src/executor.rs
+++ b/libafl_tinyinst/src/executor.rs
@@ -42,20 +42,14 @@ impl<S, SHM, OT> Debug for TinyInstExecutor<S, SHM, OT> {
     }
 }
 
-impl<EM, I, OF, OT, S, SHM> Executor<EM, I, OF, S> for TinyInstExecutor<S, SHM, OT>
+impl<I, OT, S, SHM> Executor<I, S> for TinyInstExecutor<S, SHM, OT>
 where
     S: HasExecutions,
     I: HasTargetBytes,
     SHM: ShMem,
 {
     #[inline]
-    fn run_target(
-        &mut self,
-        _objective: &mut OF,
-        state: &mut S,
-        _mgr: &mut EM,
-        input: &I,
-    ) -> Result<ExitKind, Error> {
+    fn run_target(&mut self, state: &mut S, input: &I) -> Result<ExitKind, Error> {
         *state.executions_mut() += 1;
         match &self.map {
             Some(_) => {


### PR DESCRIPTION
DO NOT MERGE!

This is unsafe, `objective` and `manager` might move between being dereferenced to a pointer in the constructor of `InProcessExecutor` and their usage in the crash handlers.